### PR TITLE
Add initial Lambda enabled Tegola Terraform module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 Azavea Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# terraform-tegola-lambda
+
+A Terraform module to create an Amazon Web Services (AWS) Lambda based [Tegola](https://tegola.io/) vector tile service.
+
+## Usage
+
+```hcl
+module "tegola" {
+  source = "github.com/azavea/terraform-tegola-lambda?ref=develop"
+
+  function_archive_path   = "${path.module}/../tegola_lambda.zip"
+  function_timeout_in_sec = "10"
+  function_memory_in_mb   = "128"
+
+  database_hostname = "database.service.tegola.internal"
+  database_name     = "tegola"
+  database_username = "tegola"
+  database_password = "tegola"
+
+  s3_cache_bucket = "tegola-cache"
+
+  vpc_id     = "vpc-20f74844"
+  subnet_ids = [...]
+
+  domain_name     = "tegola.azavea.com"
+  certificate_arn = "arn:aws:acm..."
+
+  project     = "Something"
+  environment = "Staging"
+}
+```
+
+## Variables
+
+- `vpc_id` - ID of VPC meant to house the Lambda execution environment
+- `subnet_ids` - A list of subnet IDs to launch function instances
+- `log_group_retention_in_days` - CloudWatch Log group retention period in days (default: `30`)
+- `function_archive_path` - Local file system path for Tegola archive (must contain `config.toml`)
+- `function_timeout_in_sec` - Function timeout in seconds (default: `10`)
+- `function_memory_in_mb` - Function memory in megabytes (default: `128`)
+- `s3_cache_bucket` - S3 bucket used for Tegola caching
+- `database_hostname` - PostGIS enabled PostgreSQL hostname
+- `database_port` - PostgreSQL port (default: `5432`)
+- `database_name` - PostgreSQL database name
+- `database_username` - PostgreSQL username
+- `database_password` - PostgreSQL password
+- `certificate_arn` - Amazon Resource Name (ARN) for a TLS certificate to associate with API Gateway
+- `domain_name` - Domain name to associate with API Gateway
+- `project` - Name of project for Tegola (default: `Unknown`)
+- `environment` - Name of environment Tegola is targeting (default: `Unknown`)
+
+## Outputs
+
+- `function_service_role_name` - Function IAM role name
+- `function_service_role_arn` - Function IAM role ARN
+- `function_security_group_id` - Function security group ID
+- `domain_name` - Domain name associated with API Gateway
+- `cloudfront_domain_name` - CloudFront distribution domain name associated with API Gateway
+- `cloudfront_zone_id`- CloudFront distribution zone ID associated with API Gateway

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,176 @@
+#
+# Security group resources
+#
+resource "aws_security_group" "tegola" {
+  vpc_id = "${var.vpc_id}"
+
+  tags {
+    Name        = "sgTegola"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+#
+# IAM resources
+#
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "tegola" {
+  name               = "lambda${var.environment}Tegola"
+  assume_role_policy = "${data.aws_iam_policy_document.lambda_assume_role.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_exec_policy" {
+  role       = "${aws_iam_role.tegola.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_eni_policy" {
+  role       = "${aws_iam_role.tegola.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaENIManagementAccess"
+}
+
+#
+# CloudWatch resources
+#
+resource "aws_cloudwatch_log_group" "tegola" {
+  name              = "/aws/lambda/func${var.environment}Tegola"
+  retention_in_days = "${var.log_group_retention_in_days}"
+
+  tags = {
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+#
+# Lambda resources
+#
+resource "aws_lambda_function" "tegola" {
+  filename         = "${var.function_archive_path}"
+  source_code_hash = "${base64sha256(file(var.function_archive_path))}"
+  function_name    = "func${var.environment}Tegola"
+  description      = "Function to execute the Tegola vector tile server."
+  role             = "${aws_iam_role.tegola.arn}"
+  handler          = "tegola_lambda"
+  runtime          = "go1.x"
+  timeout          = "${var.function_timeout_in_sec}"
+  memory_size      = "${var.function_memory_in_mb}"
+
+  vpc_config {
+    subnet_ids         = ["${var.subnet_ids}"]
+    security_group_ids = ["${aws_security_group.tegola.id}"]
+  }
+
+  environment {
+    variables = {
+      TEGOLA_CACHE_BUCKET      = "${var.s3_cache_bucket}"
+      TEGOLA_DATABASE_HOST     = "${var.database_hostname}"
+      TEGOLA_DATABASE_PORT     = "${var.database_port}"
+      TEGOLA_DATABASE_NAME     = "${var.database_name}"
+      TEGOLA_DATABASE_USER     = "${var.database_username}"
+      TEGOLA_DATABASE_PASSWORD = "${var.database_password}"
+    }
+  }
+
+  tags {
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+resource "aws_lambda_permission" "proxy" {
+  statement_id  = "perm${var.environment}TegolaProxy"
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.tegola.function_name}"
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_deployment.tegola.execution_arn}/*/*"
+}
+
+#
+# API Gateway resources
+#
+resource "aws_api_gateway_rest_api" "tegola" {
+  name                     = "api${var.environment}Tegola"
+  description              = "Tegola vertor tile service."
+  minimum_compression_size = 0
+
+  binary_media_types = [
+    "*/*",
+  ]
+}
+
+resource "aws_api_gateway_resource" "proxy" {
+  rest_api_id = "${aws_api_gateway_rest_api.tegola.id}"
+  parent_id   = "${aws_api_gateway_rest_api.tegola.root_resource_id}"
+  path_part   = "{proxy+}"
+}
+
+resource "aws_api_gateway_method" "proxy" {
+  rest_api_id   = "${aws_api_gateway_rest_api.tegola.id}"
+  resource_id   = "${aws_api_gateway_resource.proxy.id}"
+  http_method   = "ANY"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_method" "proxy_root" {
+  rest_api_id   = "${aws_api_gateway_rest_api.tegola.id}"
+  resource_id   = "${aws_api_gateway_rest_api.tegola.root_resource_id}"
+  http_method   = "ANY"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "tegola" {
+  rest_api_id = "${aws_api_gateway_rest_api.tegola.id}"
+  resource_id = "${aws_api_gateway_method.proxy.resource_id}"
+  http_method = "${aws_api_gateway_method.proxy.http_method}"
+
+  timeout_milliseconds    = 29000
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = "${aws_lambda_function.tegola.invoke_arn}"
+}
+
+resource "aws_api_gateway_integration" "tegola_root" {
+  rest_api_id = "${aws_api_gateway_rest_api.tegola.id}"
+  resource_id = "${aws_api_gateway_method.proxy_root.resource_id}"
+  http_method = "${aws_api_gateway_method.proxy_root.http_method}"
+
+  timeout_milliseconds    = 29000
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = "${aws_lambda_function.tegola.invoke_arn}"
+}
+
+resource "aws_api_gateway_deployment" "tegola" {
+  rest_api_id = "${aws_api_gateway_rest_api.tegola.id}"
+  stage_name  = "${lower(var.environment)}"
+
+  depends_on = [
+    "aws_api_gateway_integration.tegola",
+    "aws_api_gateway_integration.tegola_root",
+  ]
+}
+
+resource "aws_api_gateway_domain_name" "tegola" {
+  certificate_arn = "${var.certificate_arn}"
+  domain_name     = "${var.domain_name}"
+}
+
+resource "aws_api_gateway_base_path_mapping" "tegola" {
+  api_id      = "${aws_api_gateway_rest_api.tegola.id}"
+  stage_name  = "${aws_api_gateway_deployment.tegola.stage_name}"
+  domain_name = "${aws_api_gateway_domain_name.tegola.domain_name}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,28 @@
+output "function_service_role_name" {
+  value = "${aws_iam_role.tegola.name}"
+}
+
+output "function_service_role_arn" {
+  value       = "${aws_iam_role.tegola.arn}"
+  description = "Function IAM role name"
+}
+
+output "function_security_group_id" {
+  value       = "${aws_security_group.tegola.id}"
+  description = "Function IAM role ARN"
+}
+
+output "domain_name" {
+  value       = "${aws_api_gateway_domain_name.tegola.domain_name}"
+  description = "Domain name associated with API Gateway"
+}
+
+output "cloudfront_domain_name" {
+  value       = "${aws_api_gateway_domain_name.tegola.cloudfront_domain_name}"
+  description = "CloudFront distribution domain name associated with API Gateway"
+}
+
+output "cloudfront_zone_id" {
+  value       = "${aws_api_gateway_domain_name.tegola.cloudfront_zone_id}"
+  description = "CloudFront distribution zone ID associated with API Gateway"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,70 @@
+variable "project" {
+  default     = "Unknown"
+  description = "Name of project for Tegola"
+}
+
+variable "environment" {
+  default     = "Unknown"
+  description = "Name of environment Tegola is targeting"
+}
+
+variable "vpc_id" {
+  description = "ID of VPC meant to house the Lambda execution environment"
+}
+
+variable "subnet_ids" {
+  type        = "list"
+  description = "A list of subnet IDs to launch function instances"
+}
+
+variable "log_group_retention_in_days" {
+  default     = "30"
+  description = "CloudWatch Log group retention period in days"
+}
+
+variable "function_archive_path" {
+  description = "Local file system path for Tegola archive"
+}
+
+variable "function_timeout_in_sec" {
+  default     = "10"
+  description = "Function timeout in seconds"
+}
+
+variable "function_memory_in_mb" {
+  default     = "128"
+  description = "Function memory in megabytes"
+}
+
+variable "s3_cache_bucket" {
+  description = "S3 bucket used for Tegola caching"
+}
+
+variable "database_hostname" {
+  description = "PostGIS enabled PostgreSQL hostname"
+}
+
+variable "database_port" {
+  default     = "5432"
+  description = "PostgreSQL port"
+}
+
+variable "database_name" {
+  description = "PostgreSQL database name"
+}
+
+variable "database_username" {
+  description = "PostgreSQL username"
+}
+
+variable "database_password" {
+  description = "PostgreSQL password"
+}
+
+variable "certificate_arn" {
+  description = "Amazon Resource Name for a TLS certificate to associate with API Gateway"
+}
+
+variable "domain_name" {
+  description = "Domain name to associate with API Gateway"
+}


### PR DESCRIPTION
Use Terraform configuration to define all of the AWS resources needed to support an Tegola Amazon Lambda function. This includes:

- IAM roles
- Skeleton security groups
- Golang Amazon Lambda function
- API Gateway resources to make the function publicly accessible

---

**Testing**

Please use https://github.com/azavea/tegola-on-lambda-proto/pull/1 to test.